### PR TITLE
chore: set context both for rspack & rolldown

### DIFF
--- a/rolldown.config.mjs
+++ b/rolldown.config.mjs
@@ -1,10 +1,11 @@
 import { defineConfig } from "rolldown";
-
+import path from 'path';
 const isProduction = process.env.NODE_ENV === "production";
 
 export default defineConfig({
+  
   input: {
-    main: "./src/index.tsx",
+    main: path.resolve(import.meta.dirname,"./src/index.tsx"),
   },
   define: {
     "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -6,6 +6,7 @@ import ReactRefreshPlugin from "@rspack/plugin-react-refresh";
 const isProduction = process.env.NODE_ENV === "production";
 
 export default defineConfig({
+  context: import.meta.dirname,
   devtool: isProduction ? false : undefined,
   entry: {
     main: "./src/index.tsx",
@@ -61,5 +62,6 @@ export default defineConfig({
     // lazyCompilation should only be enabled in development mode
     lazyCompilation: Boolean(process.env.LAZY) && !isProduction,
     incremental: !isProduction ? true : undefined,
+    
   },
 });


### PR DESCRIPTION
use absolute path to simplify cross repo profiling experience