### PR TITLE
fix: add engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "start:rsbuild:lazy": "cross-env LAZY=true rsbuild dev",
     "build:rsbuild": "rsbuild build",
     "build:rolldown": "cross-env NODE_ENV=production rolldown -c ./rolldown.config.mjs"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
tell user to use node@22, becauase `--run` added in 22.0.0

```txt
start   Running start command: start:rspack:lazy
stderr: node: bad option: --run

error   (Rspack CLI (Lazy) 1.3.13 run start:rspack:lazy failed) child process exited with code 9

node:internal/modules/run_main:128
    triggerUncaughtException(
    ^
9
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v20.18.1
```