### PR TITLE
fix(rome): drop Rspack resolve.extensions override to match webpack

### DIFF
--- a/cases/rome/rspack.config.mjs
+++ b/cases/rome/rspack.config.mjs
@@ -6,7 +6,6 @@ export default defineConfig({
   extends: '../../shared/rspack.node.config.mjs',
   entry: './src/entry.ts',
   resolve: {
-    extensions: ['.ts', '.js'],
     tsConfig: path.resolve(import.meta.dirname, 'src/tsconfig.json'),
   },
   module: {


### PR DESCRIPTION
## What
Drop the `resolve.extensions: ['.ts', '.js']` override in `cases/rome/rspack.config.mjs` so Rspack inherits the same extensions order that the webpack case uses via the shared config.

(Superseded the original CSS-minimizer change once #ab216987 / `fix: use consistent target` on `main` switched the shared configs to `target: ['web', 'browserslist:${targetBrowser}']`, which already makes `LightningCssMinimizerRspackPlugin` auto-derive the correct targets from the browserslist. Only the rome resolve asymmetry remains.)

## Why
`cases/rome/rspack.config.mjs` explicitly sets `extensions: ['.ts', '.js']`, while `cases/rome/webpack.config.mjs` has no override and inherits `['...', '.tsx', '.ts', '.jsx']` from the shared webpack config.

The asymmetry makes the two tools resolve `./inconsiderateLanguage` differently — the directory contains both `inconsiderateLanguage.json` (a data file) and `inconsiderateLanguage.ts` (the real module). Rspack picks `.ts`; webpack picks `.json` (since `'...'` expands to defaults that put `.json` before `.ts`). That divergence ripples through the module graph and manifests as `usedExports` differences on several downstream modules (`preserveCasing`, `parser-core`, etc.) which are benchmark-config noise, not actual bundler behavior differences.

Dropping the override aligns the Rspack case with the webpack case so both end up resolving `./inconsiderateLanguage` to the same file.

## How
Remove the `extensions` field from `cases/rome/rspack.config.mjs`. The `tsConfig` field is preserved so tsconfig path resolution still works.