### PR TITLE
chore: disable utoopack build tracing by default

### DIFF
--- a/shared/utoopack.config.mjs
+++ b/shared/utoopack.config.mjs
@@ -17,6 +17,7 @@ export const createUtooConfig = (config) => {
   return {
     mode: isProd ? 'production' : 'development',
     sourceMaps: !isProd,
+    tracing: false,
     persistentCaching: true,
     stats: false,
     ...rest,


### PR DESCRIPTION
rust tracing log was closed under utoopack's framework usage: https://github.com/umijs/umi/blob/master/packages/bundler-utoopack/src/config.ts#L540