### PR TITLE
chore: enable Utoo production optimizations

### DIFF
--- a/shared/utoopack.config.mjs
+++ b/shared/utoopack.config.mjs
@@ -27,6 +27,9 @@ export const createUtooConfig = (config) => {
     },
     optimization: {
       minify: isProd,
+      concatenateModules: isProd,
+      removeUnusedExports: isProd,
+      removeUnusedImports: isProd,
       ...optimization,
     },
   };


### PR DESCRIPTION
## Summary

- enable Utoo production `concatenateModules` in the shared benchmark config
- explicitly enable Utoo production `removeUnusedExports` and `removeUnusedImports`
- keep case-level `optimization` overrides working by applying these defaults before `...optimization`

## Validation

- `pnpm --dir cases/react-1k build:utoo`
- `CASE=react-1k TOOLS=webpack,utoo pnpm benchmark` with `PUPPETEER_EXECUTABLE_PATH` pointing to local Chrome
