### PR TITLE
chore: update utoo pack to 1.4.13-alpha.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/pidusage": "^2.0.5",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
-    "@utoo/pack-cli": "^1.4.12",
+    "@utoo/pack-cli": "1.4.13-alpha.0",
     "@vitejs/plugin-react": "^6.0.2",
     "browserslist": "^4.28.2",
     "buffer": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.15)
       '@utoo/pack-cli':
-        specifier: ^1.4.12
-        version: 1.4.12(postcss@8.5.15)
+        specifier: 1.4.13-alpha.0
+        version: 1.4.13-alpha.0(postcss@8.5.15)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(terser@5.46.0)(yaml@2.9.0))
@@ -4262,63 +4262,63 @@ packages:
     peerDependencies:
       react: '>= 16.8.0'
 
-  '@utoo/pack-cli@1.4.12':
-    resolution: {integrity: sha512-8WBipGoMn0C4ykRZEIv3CmXvnx6YpzC2MpnPedWhR3kBX4s9mhSkaR5HIfqWHPQbcGLl15sobRMrXDK4e4f4zA==}
+  '@utoo/pack-cli@1.4.13-alpha.0':
+    resolution: {integrity: sha512-/vi9z5vcznkbydBXWnyevEs04HFmd7RZ4GZfVZRTcu4+pqVuyEKF4pYeh+d7t0TL2PvfCE0hj/8uovruAdeZvQ==}
     engines: {node: '>= 20'}
     hasBin: true
 
-  '@utoo/pack-darwin-arm64@1.4.12':
-    resolution: {integrity: sha512-02tZBShCSyPjnnmh4a2b7CS3YlrJZhGLSfEiFsUg3StZGSJXCgUHlpgcg+1105cNc77OrPFbwMdi+qhJTtwjJQ==}
+  '@utoo/pack-darwin-arm64@1.4.13-alpha.0':
+    resolution: {integrity: sha512-eAyOAWCwp5MQ9V1GF3J9zKvz3K7RACBf9d5OGoLubeTiHF787Hsshx53MHzngz9+29JHvJ51vXZGGR9HTGBraA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@utoo/pack-darwin-x64@1.4.12':
-    resolution: {integrity: sha512-On0zerp4EBpiu5tvHvzm+oKhYIIKOZPbD1GKyCgOrdcHY82mDw58LaGflBAVerkiFfxmR8sxUc2b8B4BFRhC1Q==}
+  '@utoo/pack-darwin-x64@1.4.13-alpha.0':
+    resolution: {integrity: sha512-1g5eictqNWrqzyb972ER3/GV2+F9ZxmjgRzmVX6fzT4S8SxDHdfphnzt8nFYQkgcguw71cwpgzkAQIrqNmAZIQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@utoo/pack-linux-arm64-gnu@1.4.12':
-    resolution: {integrity: sha512-xDf9IsgHJHuGA17x1To4WrjkpwbYzlnAWj1OusmtZ/1e6ekM8FUN1kEkORGWth8hGmNaA3vaSqYs7pUgQEMcaw==}
+  '@utoo/pack-linux-arm64-gnu@1.4.13-alpha.0':
+    resolution: {integrity: sha512-JhtE/9m1VegZz46KVvyVK5fv2qgOxHGxYKf5uGv7YWBtCM12RBf1ItAKSYhM5o4Fc8F79J3Hx3Tj5HFWc0BtLQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@utoo/pack-linux-arm64-musl@1.4.12':
-    resolution: {integrity: sha512-gRk9WJ2bb407FsNz06aPaafv91aJRRfSQ9PsAbHViRF2P0Bs9T9ZpmHVH3SBsebVeT1NdY+j1jUE7vJYw0PFhw==}
+  '@utoo/pack-linux-arm64-musl@1.4.13-alpha.0':
+    resolution: {integrity: sha512-Tjzw5dEurXin4udHkSRoRW98aXGSz8czip2l2mAqjTadT9DnNpLNMWYZZ86J6Q+nQuEKgznirHo+tGf69gfXrA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@utoo/pack-linux-x64-gnu@1.4.12':
-    resolution: {integrity: sha512-G85pEaWhooK0jvjPI0jysJ9n9DwEEQ7x9vgeHqDUF0oTbOtDw0xNIb1YvbLl6zVI7gJObV9kghFdmEgvTuVL9A==}
+  '@utoo/pack-linux-x64-gnu@1.4.13-alpha.0':
+    resolution: {integrity: sha512-aliBnzBDx8JPCxU/jr3m9244xrJu4CYkY8grQdrKzsPxQmXPMWjinzhX2hzpHqbvKAzfS/5p0ehFov5RkcM5Fg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@utoo/pack-linux-x64-musl@1.4.12':
-    resolution: {integrity: sha512-XFeqWXN6aPH5LP2Nbmtyu+lZ3KZHJ2qzt3ykTGfMf+NEkGxqzeTaTgz/v0K5ZyXXB1ueDTkLElKlvVqD7tQQsQ==}
+  '@utoo/pack-linux-x64-musl@1.4.13-alpha.0':
+    resolution: {integrity: sha512-SPWShprl2jcD2sEGAU3jfqwaZ/uLomhMwsIMmIc4PcqNn51YGddqQssRDL50zNsnHpTRp4a2lU++ctxWIe1BEA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@utoo/pack-shared@1.4.12':
-    resolution: {integrity: sha512-9wFLkCjBg4mPF7pr/S7voSy7bPX1L0Fkav8vqTjwp7CBPHElLkVJk81Sc7LU6i8+N3KnoI8esNsxnIWgLBQ9Ug==}
+  '@utoo/pack-shared@1.4.13-alpha.0':
+    resolution: {integrity: sha512-o6W+UEQwwVZK9ltfLqVKtaD1Q/liFcBXJhYgqrUX/DxJgbd9kQs0r8h03kS6hv6NWx9SXYHYvbmXnsOrO5g2aA==}
     engines: {node: '>= 20'}
 
-  '@utoo/pack-win32-x64-msvc@1.4.12':
-    resolution: {integrity: sha512-Fy/EHb5qlIKZCFLPCJ8LbEEU+TNm6Wvl5lTzsTvvFtFH5QHC/sr3IOwKVAnki3AaqlpCaMYWOoyXb3T4jdFfmQ==}
+  '@utoo/pack-win32-x64-msvc@1.4.13-alpha.0':
+    resolution: {integrity: sha512-l3v8EJ3oIXapca+AoaCQEclvCWWTA5KEqCCOi3IO5lVaFz6bfpiZZvtdZiiZeER5eXiss5Wj7Vcd9MAx+Iu1dQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@utoo/pack@1.4.12':
-    resolution: {integrity: sha512-dN0Sq7+Tp7ct9D5r+ULBp9IYdwj67yNsMW725mW4fURCf0QkPK6G15QEF/UKf1fsx37FehEjs+0mznznFUtTUw==}
+  '@utoo/pack@1.4.13-alpha.0':
+    resolution: {integrity: sha512-cEsn7QXGSEpmuxYMLmyJYt9Fq5FsPAsRC00c/uuV746Bq6Cue8eYz3HJ+zo4s1IRrCA2ToVK0gtfzeU1OHigVg==}
     engines: {node: '>= 20'}
     peerDependencies:
       less: ^4.0.0
@@ -13529,9 +13529,9 @@ snapshots:
       '@use-gesture/core': 10.3.0
       react: 19.2.6
 
-  '@utoo/pack-cli@1.4.12(postcss@8.5.15)':
+  '@utoo/pack-cli@1.4.13-alpha.0(postcss@8.5.15)':
     dependencies:
-      '@utoo/pack': 1.4.12(postcss@8.5.15)
+      '@utoo/pack': 1.4.13-alpha.0(postcss@8.5.15)
       citty: 0.1.6
     transitivePeerDependencies:
       - bufferutil
@@ -13545,39 +13545,39 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@utoo/pack-darwin-arm64@1.4.12':
+  '@utoo/pack-darwin-arm64@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-darwin-x64@1.4.12':
+  '@utoo/pack-darwin-x64@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-linux-arm64-gnu@1.4.12':
+  '@utoo/pack-linux-arm64-gnu@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-linux-arm64-musl@1.4.12':
+  '@utoo/pack-linux-arm64-musl@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-linux-x64-gnu@1.4.12':
+  '@utoo/pack-linux-x64-gnu@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-linux-x64-musl@1.4.12':
+  '@utoo/pack-linux-x64-musl@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack-shared@1.4.12':
+  '@utoo/pack-shared@1.4.13-alpha.0':
     dependencies:
       '@babel/code-frame': 7.22.5
       picocolors: 1.1.1
 
-  '@utoo/pack-win32-x64-msvc@1.4.12':
+  '@utoo/pack-win32-x64-msvc@1.4.13-alpha.0':
     optional: true
 
-  '@utoo/pack@1.4.12(postcss@8.5.15)':
+  '@utoo/pack@1.4.13-alpha.0(postcss@8.5.15)':
     dependencies:
       '@babel/code-frame': 7.22.5
       '@hono/node-server': 1.19.14(hono@4.12.21)
       '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.21))(hono@4.12.21)
       '@swc/helpers': 0.5.15
-      '@utoo/pack-shared': 1.4.12
+      '@utoo/pack-shared': 1.4.13-alpha.0
       domparser-rs: 0.0.7
       find-up: 4.1.0
       get-port: 5.1.1
@@ -13589,13 +13589,13 @@ snapshots:
       send: 0.17.1
       ws: 8.19.0
     optionalDependencies:
-      '@utoo/pack-darwin-arm64': 1.4.12
-      '@utoo/pack-darwin-x64': 1.4.12
-      '@utoo/pack-linux-arm64-gnu': 1.4.12
-      '@utoo/pack-linux-arm64-musl': 1.4.12
-      '@utoo/pack-linux-x64-gnu': 1.4.12
-      '@utoo/pack-linux-x64-musl': 1.4.12
-      '@utoo/pack-win32-x64-msvc': 1.4.12
+      '@utoo/pack-darwin-arm64': 1.4.13-alpha.0
+      '@utoo/pack-darwin-x64': 1.4.13-alpha.0
+      '@utoo/pack-linux-arm64-gnu': 1.4.13-alpha.0
+      '@utoo/pack-linux-arm64-musl': 1.4.13-alpha.0
+      '@utoo/pack-linux-x64-gnu': 1.4.13-alpha.0
+      '@utoo/pack-linux-x64-musl': 1.4.13-alpha.0
+      '@utoo/pack-win32-x64-msvc': 1.4.13-alpha.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
## Summary

- Update `@utoo/pack-cli` to `1.4.13-alpha.0`.
- Refresh `pnpm-lock.yaml` so `@utoo/pack` and related platform packages resolve to `1.4.13-alpha.0`.

## Validation

- `pnpm list @utoo/pack-cli @utoo/pack --depth 2`
- `pnpm why @utoo/pack`
- `pnpm --dir cases/react-1k run build:utoo`

Note: local validation used the bundled Node.js `v24.14.0`, which emits an engine warning because the project declares `node >=24.15.0`, but the commands completed successfully.