### PR TITLE
Add Bun to the benchmark suite

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           node-version: 24.16.0
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2
+        with:
+          bun-version: latest
+
       - name: Install Global Dependencies
         run: |
           npm i cross-env -g

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build Tools Comparison
 
-Benchmark comparing JavaScript bundlers and build tools ([Rspack](https://github.com/web-infra-dev/rspack), [Rsbuild](https://github.com/web-infra-dev/rsbuild), [webpack](https://github.com/webpack/webpack), [Vite](https://github.com/vitejs/vite), [Rolldown](https://github.com/rolldown/rolldown), [esbuild](https://github.com/evanw/esbuild), [Rollup](https://github.com/rollup/rollup), [Parcel](https://github.com/parcel-bundler/parcel), [Farm](https://github.com/farm-fe/farm) and [Utoo](https://github.com/utooland/utoo)) for dev server startup time, build performance and bundle size for applications with different module sizes.
+Benchmark comparing JavaScript bundlers and build tools ([Rspack](https://github.com/web-infra-dev/rspack), [Rsbuild](https://github.com/web-infra-dev/rsbuild), [webpack](https://github.com/webpack/webpack), [Vite](https://github.com/vitejs/vite), [Rolldown](https://github.com/rolldown/rolldown), [esbuild](https://github.com/evanw/esbuild), [Rollup](https://github.com/rollup/rollup), [Parcel](https://github.com/parcel-bundler/parcel), [Farm](https://github.com/farm-fe/farm), [Utoo](https://github.com/utooland/utoo) and [Bun](https://github.com/oven-sh/bun)) for dev server startup time, build performance and bundle size for applications with different module sizes.
 
 ## Metrics
 
@@ -26,6 +26,7 @@ Tooling details:
 
 - webpack is configured to use SWC instead of Babel / Terser.
 - Vite uses Rolldown and Oxc.
+- Bun is a native binary rather than an npm dependency, so it must be installed separately (see https://bun.sh). The benchmark invokes the `bun` executable on your `PATH`.
 
 ## Results
 

--- a/cases/popular-libs/benchmark-config.mjs
+++ b/cases/popular-libs/benchmark-config.mjs
@@ -9,6 +9,7 @@ export const config = {
     'esbuild',
     'farm',
     'utoo',
+    'bun',
     // Parcel cannot bundle Zod
     // https://github.com/parcel-bundler/parcel/issues/10175
     // 'parcel',

--- a/cases/popular-libs/bun.mjs
+++ b/cases/popular-libs/bun.mjs
@@ -1,0 +1,5 @@
+import bunBuild from '../../shared/bun.mjs';
+
+await bunBuild({
+  entrypoints: ['./src/index.js'],
+});

--- a/cases/popular-libs/package.json
+++ b/cases/popular-libs/package.json
@@ -11,7 +11,8 @@
     "build:utoo": "cross-env NODE_ENV=production up build",
     "build:farm": "farm build",
     "build:vite": "vite build",
-    "build:esbuild": "cross-env NODE_ENV=production node esbuild.mjs"
+    "build:esbuild": "cross-env NODE_ENV=production node esbuild.mjs",
+    "build:bun": "cross-env NODE_ENV=production bun bun.mjs"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",

--- a/cases/react-10k/benchmark-config.mjs
+++ b/cases/react-10k/benchmark-config.mjs
@@ -7,9 +7,10 @@ export const config = {
     'farm',
     'parcel',
     'utoo',
+    'bun',
   ],
   // Farm, Parcel and Utoo are not enabled because the CI will fail
-  defaultTools: ['rspack', 'rsbuild', 'vite', 'webpack'],
+  defaultTools: ['rspack', 'rsbuild', 'vite', 'webpack', 'bun'],
   rootFile: 'f0.jsx',
   leafFile: 'd0/d0/d0/f0.jsx',
 };

--- a/cases/react-10k/bun-server.mjs
+++ b/cases/react-10k/bun-server.mjs
@@ -1,0 +1,22 @@
+// Bun is a native binary, so the benchmark runner cannot inject its console
+// logging into the bin file. We log the required metrics directly here.
+console.log('Benchmark Start Time:', Date.now());
+console.log('Current PID:', process.pid);
+
+process.on('exit', () => {
+  console.log('Memory Usage:', process.memoryUsage().rss);
+});
+
+// Dynamic import keeps the logs above from being hoisted below the (potentially
+// expensive) HTML bundling that Bun performs when the module is evaluated.
+const { default: index } = await import('./index.html');
+
+const server = Bun.serve({
+  port: 1234,
+  development: { hmr: true },
+  routes: {
+    '/': index,
+  },
+});
+
+console.log(`Bun dev server ready at ${server.url}`);

--- a/cases/react-10k/bun.mjs
+++ b/cases/react-10k/bun.mjs
@@ -1,0 +1,5 @@
+import bunBuild from '../../shared/bun.mjs';
+
+await bunBuild({
+  entrypoints: ['./index.html'],
+});

--- a/cases/react-10k/package.json
+++ b/cases/react-10k/package.json
@@ -10,13 +10,15 @@
     "build:utoo": "cross-env NODE_ENV=production up build",
     "build:vite": "vite build",
     "build:webpack": "cross-env NODE_ENV=production webpack build --mode production",
+    "build:bun": "cross-env NODE_ENV=production bun bun.mjs",
     "start:farm": "farm start",
     "start:parcel": "parcel -p 3200 index.html",
     "start:rsbuild": "rsbuild dev",
     "start:rspack": "rspack serve",
     "start:utoo": "cross-env NODE_ENV=development up dev",
     "start:vite": "vite",
-    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development"
+    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development",
+    "start:bun": "bun bun-server.mjs"
   },
   "dependencies": {
     "@iconify-icons/material-symbols": "^1.2.58",

--- a/cases/react-1k/benchmark-config.mjs
+++ b/cases/react-1k/benchmark-config.mjs
@@ -7,6 +7,7 @@ export const config = {
     'farm',
     'parcel',
     'utoo',
+    'bun',
   ],
   rootFile: 'f0.jsx',
   leafFile: 'd0/d0/d0/f0.jsx',

--- a/cases/react-1k/bun-server.mjs
+++ b/cases/react-1k/bun-server.mjs
@@ -1,0 +1,22 @@
+// Bun is a native binary, so the benchmark runner cannot inject its console
+// logging into the bin file. We log the required metrics directly here.
+console.log('Benchmark Start Time:', Date.now());
+console.log('Current PID:', process.pid);
+
+process.on('exit', () => {
+  console.log('Memory Usage:', process.memoryUsage().rss);
+});
+
+// Dynamic import keeps the logs above from being hoisted below the (potentially
+// expensive) HTML bundling that Bun performs when the module is evaluated.
+const { default: index } = await import('./index.html');
+
+const server = Bun.serve({
+  port: 1234,
+  development: { hmr: true },
+  routes: {
+    '/': index,
+  },
+});
+
+console.log(`Bun dev server ready at ${server.url}`);

--- a/cases/react-1k/bun.mjs
+++ b/cases/react-1k/bun.mjs
@@ -1,0 +1,5 @@
+import bunBuild from '../../shared/bun.mjs';
+
+await bunBuild({
+  entrypoints: ['./index.html'],
+});

--- a/cases/react-1k/package.json
+++ b/cases/react-1k/package.json
@@ -10,13 +10,15 @@
     "build:utoo": "cross-env NODE_ENV=production up build",
     "build:vite": "vite build",
     "build:webpack": "cross-env NODE_ENV=production webpack build --mode production",
+    "build:bun": "cross-env NODE_ENV=production bun bun.mjs",
     "start:farm": "farm start",
     "start:parcel": "parcel -p 3200 index.html",
     "start:rsbuild": "rsbuild dev",
     "start:rspack": "rspack serve",
     "start:utoo": "cross-env NODE_ENV=development up dev",
     "start:vite": "vite",
-    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development"
+    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development",
+    "start:bun": "bun bun-server.mjs"
   },
   "dependencies": {
     "@iconify-icons/material-symbols": "^1.2.58",

--- a/cases/react-5k/benchmark-config.mjs
+++ b/cases/react-5k/benchmark-config.mjs
@@ -7,9 +7,18 @@ export const config = {
     'farm',
     'parcel',
     'utoo',
+    'bun',
   ],
   // Utoo is not enabled because the CI will fail
-  defaultTools: ['rspack', 'rsbuild', 'vite', 'webpack', 'farm', 'parcel'],
+  defaultTools: [
+    'rspack',
+    'rsbuild',
+    'vite',
+    'webpack',
+    'farm',
+    'parcel',
+    'bun',
+  ],
   rootFile: 'f0.jsx',
   leafFile: 'd0/d0/d0/f0.jsx',
 };

--- a/cases/react-5k/bun-server.mjs
+++ b/cases/react-5k/bun-server.mjs
@@ -1,0 +1,22 @@
+// Bun is a native binary, so the benchmark runner cannot inject its console
+// logging into the bin file. We log the required metrics directly here.
+console.log('Benchmark Start Time:', Date.now());
+console.log('Current PID:', process.pid);
+
+process.on('exit', () => {
+  console.log('Memory Usage:', process.memoryUsage().rss);
+});
+
+// Dynamic import keeps the logs above from being hoisted below the (potentially
+// expensive) HTML bundling that Bun performs when the module is evaluated.
+const { default: index } = await import('./index.html');
+
+const server = Bun.serve({
+  port: 1234,
+  development: { hmr: true },
+  routes: {
+    '/': index,
+  },
+});
+
+console.log(`Bun dev server ready at ${server.url}`);

--- a/cases/react-5k/bun.mjs
+++ b/cases/react-5k/bun.mjs
@@ -1,0 +1,5 @@
+import bunBuild from '../../shared/bun.mjs';
+
+await bunBuild({
+  entrypoints: ['./index.html'],
+});

--- a/cases/react-5k/package.json
+++ b/cases/react-5k/package.json
@@ -10,13 +10,15 @@
     "build:utoo": "cross-env NODE_ENV=production up build",
     "build:vite": "vite build",
     "build:webpack": "cross-env NODE_ENV=production webpack build --mode production",
+    "build:bun": "cross-env NODE_ENV=production bun bun.mjs",
     "start:farm": "farm start",
     "start:parcel": "parcel -p 3200 index.html",
     "start:rsbuild": "rsbuild dev",
     "start:rspack": "rspack serve",
     "start:utoo": "cross-env NODE_ENV=development up dev",
     "start:vite": "vite",
-    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development"
+    "start:webpack": "cross-env NODE_ENV=development webpack serve --mode development",
+    "start:bun": "bun bun-server.mjs"
   },
   "dependencies": {
     "@iconify-icons/material-symbols": "^1.2.58",

--- a/cases/ui-components/benchmark-config.mjs
+++ b/cases/ui-components/benchmark-config.mjs
@@ -12,6 +12,7 @@ export const config = {
     'farm',
     'parcel',
     'utoo',
+    'bun',
   ],
   dev: false,
 };

--- a/cases/ui-components/bun.mjs
+++ b/cases/ui-components/bun.mjs
@@ -1,0 +1,5 @@
+import bunBuild from '../../shared/bun.mjs';
+
+await bunBuild({
+  entrypoints: ['./src/index.js'],
+});

--- a/cases/ui-components/package.json
+++ b/cases/ui-components/package.json
@@ -11,7 +11,8 @@
     "build:utoo": "cross-env NODE_ENV=production up build",
     "build:farm": "farm build",
     "build:vite": "vite build",
-    "build:esbuild": "cross-env NODE_ENV=production node esbuild.mjs"
+    "build:esbuild": "cross-env NODE_ENV=production node esbuild.mjs",
+    "build:bun": "cross-env NODE_ENV=production bun bun.mjs"
   },
   "dependencies": {
     "@arco-design/web-react": "^2.66.15",

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from 'node:child_process';
+import { spawn, execSync, type ChildProcess } from 'node:child_process';
 import { appendFile, readFileSync, writeFileSync } from 'node:fs';
 import fse from 'fs-extra';
 import { createRequire } from 'module';
@@ -40,7 +40,7 @@ type BenchmarkConfig = {
 
 type DevServerResult = {
   time: number;
-  stopServer: () => Promise<number>;
+  stopServer: () => Promise<number | null>;
 };
 
 type BuildResult = {
@@ -79,6 +79,26 @@ async function coolDown(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, COOL_DOWN_TIME));
 }
 
+// `pidusage` can hang indefinitely on some platforms (e.g. recent Windows where
+// `wmic` has been removed). Race it against a timeout so a stuck call can never
+// block the benchmark; callers treat a `null` result as "stats unavailable".
+const PIDUSAGE_TIMEOUT = 5000;
+
+async function safePidusage(
+  pid: number,
+): Promise<{ cpu: number; memory: number } | null> {
+  try {
+    return await Promise.race([
+      pidusage(pid),
+      new Promise<null>((resolve) =>
+        setTimeout(() => resolve(null), PIDUSAGE_TIMEOUT),
+      ),
+    ]);
+  } catch {
+    return null;
+  }
+}
+
 const ensureMetrics = (
   perfResult: PerfResultMap,
   toolName: string,
@@ -115,8 +135,11 @@ interface BuildToolOptions {
   startScript: string;
   startedRegex: RegExp;
   buildScript: string;
-  binFilePath: string;
+  binFilePath?: string;
   skipRss?: boolean;
+  // Native-binary tools (e.g. Bun) cannot have the benchmark console injected
+  // into their bin file, so they log the metrics from their own scripts.
+  skipBinHack?: boolean;
 }
 
 class BuildTool {
@@ -136,14 +159,19 @@ class BuildTool {
     buildScript,
     binFilePath,
     skipRss = false,
+    skipBinHack = false,
   }: BuildToolOptions) {
     this.name = name;
     this.port = port;
     this.startScript = startScript;
     this.startedRegex = startedRegex;
     this.buildScript = buildScript;
-    this.binFilePath = path.join(process.cwd(), 'node_modules', binFilePath);
-    this.hackBinFile();
+    if (skipBinHack || !binFilePath) {
+      this.binFilePath = '';
+    } else {
+      this.binFilePath = path.join(process.cwd(), 'node_modules', binFilePath);
+      this.hackBinFile();
+    }
     this.skipRss = skipRss;
   }
 
@@ -215,7 +243,7 @@ class BuildTool {
       let startTime: number | null = null;
       let bundlerPid: number | null = null;
 
-      const stopServer = async () => {
+      const stopServer = async (): Promise<number | null> => {
         if (!bundlerPid) {
           throw new Error('Bundler pid not found');
         }
@@ -224,17 +252,20 @@ class BuildTool {
         const start = Date.now();
         // wait bundler write cache to disk
         while (Date.now() - start < TIMEOUT) {
-          const info = await pidusage(bundlerPid);
-          // CPU idle
-          if (info.cpu === 0) {
+          const info = await safePidusage(bundlerPid);
+          // CPU idle, or process stats unavailable on this platform
+          if (!info || info.cpu === 0) {
             break;
           }
           await sleep(200);
         }
 
-        const info = await pidusage(bundlerPid);
-        const rssRaw = info.memory / 1024 / 1024;
-        const rss = Math.round(rssRaw * 1000) / 1000;
+        const info = await safePidusage(bundlerPid);
+        let rss: number | null = null;
+        if (info) {
+          const rssRaw = info.memory / 1024 / 1024;
+          rss = Math.round(rssRaw * 1000) / 1000;
+        }
 
         if (child.pid) {
           kill(child.pid);
@@ -464,6 +495,29 @@ parseToolNames().forEach((name) => {
         }),
       );
       break;
+    case 'bun': {
+      let bunVersion = '';
+      try {
+        // Bun is installed at the system level, so read the version from the
+        // binary rather than from a node_modules package.
+        bunVersion = execSync('bun --version').toString().trim();
+      } catch {
+        // bun version is optional
+      }
+      buildTools.push(
+        new BuildTool({
+          name: ('Bun ' + bunVersion).trim(),
+          port: 1234,
+          startScript: 'start:bun',
+          startedRegex: /Bun dev server ready/,
+          buildScript: 'build:bun',
+          // Bun is a native binary and logs benchmark metrics from its own
+          // build/dev scripts instead of via an injected bin file.
+          skipBinHack: true,
+        }),
+      );
+      break;
+    }
   }
 });
 
@@ -625,7 +679,9 @@ async function runDevBenchmark(
   writeFileSync(leafFilePath, originalLeafFileContent);
 
   const rss = await stopServer();
-  metrics.devRSS = rss;
+  if (rss !== null) {
+    metrics.devRSS = rss;
+  }
 
   await coolDown();
   logger.success(color.dim(buildTool.name) + ' dev server closed');

--- a/shared/bun.mjs
+++ b/shared/bun.mjs
@@ -1,0 +1,31 @@
+import { isProd } from './constants.mjs';
+
+// Bun is a native binary, so the benchmark runner cannot inject the memory
+// logging into its bin file. Instead we log it directly from the build script,
+// which is executed by the Bun runtime.
+process.on('exit', () => {
+  console.log('Memory Usage:', process.memoryUsage().rss);
+});
+
+export default async (options) => {
+  const result = await Bun.build({
+    outdir: 'dist',
+    target: 'browser',
+    splitting: true,
+    minify: isProd,
+    sourcemap: isProd ? 'none' : 'linked',
+    define: {
+      'process.env.NODE_ENV': JSON.stringify(
+        isProd ? 'production' : 'development',
+      ),
+    },
+    ...options,
+  });
+
+  if (!result.success) {
+    for (const message of result.logs) {
+      console.error(message);
+    }
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
Adds Bun as a compared bundler across all benchmark cases (build + dev/HMR for the React cases).

- New shared/bun.mjs build helper (code-splitting, prod minify, NODE_ENV define, logs Memory Usage on exit)
- Per-case bun.mjs build entries and bun-server.mjs dev servers (Bun.serve with HMR) for react-1k/5k/10k
- benchmark.ts: 'bun' case (system Bun binary, skipBinHack, version via bun --version) and a safePidusage timeout wrapper
- package.json: build:bun / start:bun scripts; benchmark-config.mjs: bun in supported/default tools
- README + CI: oven-sh/setup-bun step (Bun is a native binary installed separately)