### PR TITLE
chore: bump webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tree-kill": "^1.2.2",
     "typescript": "^6.0.3",
     "vite": "^8.1.0",
-    "webpack": "^5.108.1",
+    "webpack": "^5.108.3",
     "webpack-cli": "^7.1.0",
     "webpack-dev-server": "^5.2.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.16.4(@parcel/core@2.16.4(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.6.2
-        version: 0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.5)(webpack@5.108.1)
+        version: 0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.5)(webpack@5.108.3)
       '@rollup/plugin-alias':
         specifier: ^6.0.0
         version: 6.0.0(rollup@4.62.2)
@@ -49,7 +49,7 @@ importers:
         version: 2.1.0(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.16
-        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       '@rspack/cli':
         specifier: ^2.1.1
         version: 2.1.1(@rspack/core@2.1.1(@swc/helpers@0.5.23))(@rspack/dev-server@2.1.0(@rspack/core@2.1.1(@swc/helpers@0.5.23))(selfsigned@5.5.0))
@@ -97,7 +97,7 @@ importers:
         version: 10.1.0
       css-minimizer-webpack-plugin:
         specifier: ^8.0.0
-        version: 8.0.0(esbuild@0.28.1)(lightningcss@1.32.0)(webpack@5.108.1)
+        version: 8.0.0(esbuild@0.28.1)(lightningcss@1.32.0)(webpack@5.108.3)
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -112,7 +112,7 @@ importers:
         version: 7.0.0
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       lightningcss:
         specifier: ^1.32.0
         version: 1.32.0
@@ -160,10 +160,10 @@ importers:
         version: 2.1.3
       swc-loader:
         specifier: ^0.2.7
-        version: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1)
+        version: 0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.3)
       terser-webpack-plugin:
         specifier: ^5.6.1
-        version: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.1)
+        version: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.3)
       tree-kill:
         specifier: ^1.2.2
         version: 1.2.2
@@ -174,14 +174,14 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(terser@5.46.0)(yaml@2.9.0)
       webpack:
-        specifier: ^5.108.1
-        version: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+        specifier: ^5.108.3
+        version: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
       webpack-cli:
         specifier: ^7.1.0
-        version: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.1)
+        version: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.3)
       webpack-dev-server:
         specifier: ^5.2.5
-        version: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.1)
+        version: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.3)
 
   cases/popular-libs:
     dependencies:
@@ -9100,8 +9100,8 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
-  webpack@5.108.1:
-    resolution: {integrity: sha512-UUCihHQK3O7483Woa0SulNLDeAiOhHI2PN2PAPU4fVWJqbzhv04EJ8FaWtB9WWh3i8fRt28543U7VfuJTOrpgQ==}
+  webpack@5.108.3:
+    resolution: {integrity: sha512-hOpaCHmQVVY66IVTjofnH14IgSdmod2aquSGHGuYig/OIdWge01Hk2Wt988DZcwXumFUT4+FvJY5N+ikl8o/ww==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -11374,7 +11374,7 @@ snapshots:
       tslib: 2.8.1
       tsyringe: 4.10.0
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.5)(webpack@5.108.1)':
+  '@pmmmwh/react-refresh-webpack-plugin@0.6.2(react-refresh@0.18.0)(type-fest@5.7.0)(webpack-dev-server@5.2.5)(webpack@5.108.3)':
     dependencies:
       anser: 2.3.5
       core-js-pure: 3.48.0
@@ -11383,10 +11383,10 @@ snapshots:
       react-refresh: 0.18.0
       schema-utils: 4.3.3
       source-map: 0.7.6
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
     optionalDependencies:
       type-fest: 5.7.0
-      webpack-dev-server: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.1)
+      webpack-dev-server: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.3)
 
   '@popperjs/core@2.11.8': {}
 
@@ -12866,13 +12866,13 @@ snapshots:
 
   '@rsdoctor/client@1.5.16': {}
 
-  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/core@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.1(core-js@3.48.0))
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.47.1
@@ -12890,10 +12890,10 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/graph@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/graph@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       es-toolkit: 1.47.1
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -12901,13 +12901,13 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/rspack-plugin@1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
-      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/core': 1.5.16(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@rsbuild/core@2.1.1(core-js@3.48.0))(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/sdk': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
     optionalDependencies:
       '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
     transitivePeerDependencies:
@@ -12919,12 +12919,12 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/sdk@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
       '@rsdoctor/client': 1.5.16
-      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
-      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/graph': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
+      '@rsdoctor/utils': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       launch-editor: 2.13.2
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -12936,7 +12936,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/types@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/types@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
@@ -12944,12 +12944,12 @@ snapshots:
       source-map: 0.7.6
     optionalDependencies:
       '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
 
-  '@rsdoctor/utils@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)':
+  '@rsdoctor/utils@1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1)
+      '@rsdoctor/types': 1.5.16(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -15054,7 +15054,7 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
-  css-minimizer-webpack-plugin@8.0.0(esbuild@0.28.1)(lightningcss@1.32.0)(webpack@5.108.1):
+  css-minimizer-webpack-plugin@8.0.0(esbuild@0.28.1)(lightningcss@1.32.0)(webpack@5.108.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.2(postcss@8.5.14)
@@ -15062,7 +15062,7 @@ snapshots:
       postcss: 8.5.14
       schema-utils: 4.3.3
       serialize-javascript: 7.0.4
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
     optionalDependencies:
       esbuild: 0.28.1
       lightningcss: 1.32.0
@@ -16036,7 +16036,7 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
-  html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.1):
+  html-webpack-plugin@5.6.7(@rspack/core@2.1.1(@swc/helpers@0.5.23))(webpack@5.108.3):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -16045,7 +16045,7 @@ snapshots:
       tapable: 2.3.2
     optionalDependencies:
       '@rspack/core': 2.1.1(@swc/helpers@0.5.23)
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
 
   htmlparser2@10.0.0:
     dependencies:
@@ -16714,13 +16714,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.13
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.1):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
       esbuild: 0.28.1
@@ -18499,11 +18499,11 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.4
 
-  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.1):
+  swc-loader@0.2.7(@swc/core@1.15.43(@swc/helpers@0.5.23))(webpack@5.108.3):
     dependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
       '@swc/counter': 0.1.3
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
 
   swiper@12.2.0: {}
 
@@ -18546,13 +18546,13 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.1):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
     optionalDependencies:
       '@swc/core': 1.15.43(@swc/helpers@0.5.23)
       esbuild: 0.28.1
@@ -18873,7 +18873,7 @@ snapshots:
 
   webdriver-bidi-protocol@0.3.9: {}
 
-  webpack-cli@7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.1):
+  webpack-cli@7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.3):
     dependencies:
       '@discoveryjs/json-ext': 1.1.0
       commander: 14.0.3
@@ -18882,14 +18882,14 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
       webpack-merge: 6.0.1
     optionalDependencies:
       js-yaml: 4.1.1
       json5: 2.2.3
-      webpack-dev-server: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.1)
+      webpack-dev-server: 5.2.5(webpack-cli@7.1.0)(webpack@5.108.3)
 
-  webpack-dev-middleware@7.4.5(webpack@5.108.1):
+  webpack-dev-middleware@7.4.5(webpack@5.108.3):
     dependencies:
       colorette: 2.0.20
       memfs: 4.56.10
@@ -18898,9 +18898,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
 
-  webpack-dev-server@5.2.5(webpack-cli@7.1.0)(webpack@5.108.1):
+  webpack-dev-server@5.2.5(webpack-cli@7.1.0)(webpack@5.108.3):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -18928,11 +18928,11 @@ snapshots:
       serve-index: 1.9.2
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.108.1)
+      webpack-dev-middleware: 7.4.5(webpack@5.108.3)
       ws: 8.19.0
     optionalDependencies:
-      webpack: 5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
-      webpack-cli: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.1)
+      webpack: 5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0)
+      webpack-cli: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -18949,7 +18949,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.108.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0):
+  webpack@5.108.3(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.1.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -18967,14 +18967,14 @@ snapshots:
       graceful-fs: 4.2.11
       loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.1)
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43(@swc/helpers@0.5.23))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.3)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     optionalDependencies:
-      webpack-cli: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.1)
+      webpack-cli: 7.1.0(js-yaml@4.1.1)(json5@2.2.3)(webpack-dev-server@5.2.5)(webpack@5.108.3)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'


### PR DESCRIPTION
Sorry for delay. Fixes https://github.com/rstackjs/build-tools-performance/pull/152#issuecomment-4829758358. 

Testing between v5.108.1 and v5.108.3:

<img width="425" height="163" alt="image" src="https://github.com/user-attachments/assets/ab357faf-360d-464f-bf86-8f6e2c102a0d" />
